### PR TITLE
Localforage, browserify and IE8 do not play nicely together

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,13 +37,17 @@
     "phantomjs": "^1.9.7-12",
     "uglify-js": "^2.3.x"
   },
-  "browser": "src/localforage.js",
+  "browser": {
+    "dist/localforage.js": "./src/localforage.js",
+    "promise": "./src/browser-promise.js"
+  },
   "main": "dist/localforage.js",
   "licence": "Apache-2.0",
   "bugs": {
     "url": "http://github.com/mozilla/localForage/issues"
   },
   "dependencies": {
-    "promise": "^5.0.0"
+    "promise": "^5.0.0",
+    "es6-promise": "~1.0.0"
   }
 }

--- a/src/browser-promise.js
+++ b/src/browser-promise.js
@@ -1,0 +1,1 @@
+module.exports = require('es6-promise').Promise;


### PR DESCRIPTION
When requiring localforage with browserify IE8 baulks with 'Object doesn't support this property or method' type errors. 

This is due to the fact that browserify will bundle up the `promise` module which is not es3 compatible. The compiled version (in the dist directory) uses a different promise library - `es6-promise` which _is_ es3 compatible. This PR contains a tweak so that browserify will also bring in `es6-promise`.

It's not a very elegant solution, in fact it feels a bit hacky, but I erred on the side of caution and tried not to touch anything.

Note that even with this change a browserified version of this package is still not quite IE8 ready. For that you need to filter out the es3 reserved keywords using something like [dekeywordify](https://github.com/pluma/dekeywordify)