### PR TITLE
Test for commonjs first so webpack will work

### DIFF
--- a/src/drivers/indexeddb.js
+++ b/src/drivers/indexeddb.js
@@ -401,12 +401,12 @@
         keys: keys
     };
 
-    if (typeof define === 'function' && define.amd) {
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = asyncStorage;
+    } else if (typeof define === 'function' && define.amd) {
         define('asyncStorage', function() {
             return asyncStorage;
         });
-    } else if (typeof module !== 'undefined' && module.exports) {
-        module.exports = asyncStorage;
     } else {
         this.asyncStorage = asyncStorage;
     }

--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -43,10 +43,10 @@
 
     // Find out what kind of module setup we have; if none, we'll just attach
     // localForage to the main window.
-    if (typeof define === 'function' && define.amd) {
-        moduleType = ModuleType.DEFINE;
-    } else if (typeof module !== 'undefined' && module.exports) {
+    if (typeof module !== 'undefined' && module.exports) {
         moduleType = ModuleType.EXPORT;
+    } else if (typeof define === 'function' && define.amd) {
+        moduleType = ModuleType.DEFINE;
     }
 
     // Config the localStorage backend, using options set in the config.
@@ -317,12 +317,12 @@
         keys: keys
     };
 
-    if (moduleType === ModuleType.DEFINE) {
+    if (moduleType === ModuleType.EXPORT) {
+        module.exports = localStorageWrapper;
+    } else if (moduleType === ModuleType.DEFINE) {
         define('localStorageWrapper', function() {
             return localStorageWrapper;
         });
-    } else if (moduleType === ModuleType.EXPORT) {
-        module.exports = localStorageWrapper;
     } else {
         this.localStorageWrapper = localStorageWrapper;
     }

--- a/src/drivers/websql.js
+++ b/src/drivers/websql.js
@@ -35,10 +35,10 @@
 
     // Find out what kind of module setup we have; if none, we'll just attach
     // localForage to the main window.
-    if (typeof define === 'function' && define.amd) {
-        moduleType = ModuleType.DEFINE;
-    } else if (typeof module !== 'undefined' && module.exports) {
+    if (typeof module !== 'undefined' && module.exports) {
         moduleType = ModuleType.EXPORT;
+    } else if (typeof define === 'function' && define.amd) {
+        moduleType = ModuleType.DEFINE;
     }
 
     // Open the WebSQL database (automatically creates one if one didn't

--- a/src/localforage.js
+++ b/src/localforage.js
@@ -55,10 +55,10 @@
 
     // Find out what kind of module setup we have; if none, we'll just attach
     // localForage to the main window.
-    if (typeof define === 'function' && define.amd) {
-        moduleType = ModuleType.DEFINE;
-    } else if (typeof module !== 'undefined' && module.exports) {
+    if (typeof module !== 'undefined' && module.exports) {
         moduleType = ModuleType.EXPORT;
+    } else if (typeof define === 'function' && define.amd) {
+        moduleType = ModuleType.DEFINE;
     }
 
     // Check to see if IndexedDB is available and if it is the latest

--- a/src/utils/serializer.js
+++ b/src/utils/serializer.js
@@ -218,12 +218,12 @@
         bufferToString: bufferToString
     };
 
-    if (typeof define === 'function' && define.amd) {
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = localforageSerializer;
+    } else if (typeof define === 'function' && define.amd) {
         define('localforageSerializer', function() {
             return localforageSerializer;
         });
-    } else if (typeof module !== 'undefined' && module.exports) {
-        module.exports = localforageSerializer;
     } else {
         this.localforageSerializer = localforageSerializer;
     }


### PR DESCRIPTION
I'm seeing a problem consuming localforage in webpack right now that seems to be due to `define.amd` existing but webpack expecting commonjs-style exports. 

This is a working solution, but there might be a better/less fragile solution to this, happy to do something else if you have suggestions or I can find out how this is dealt with by other packages.