### PR TITLE
test(createInstance): add test for same-name multiple instances #342

### DIFF
--- a/test/test.api.js
+++ b/test/test.api.js
@@ -634,6 +634,7 @@ DRIVERS.forEach(function(driverName) {
     describe(driverName + ' driver multiple instances', function() {
         'use strict';
         var localforage2 = null;
+        var localforage3 = null;
         var Promise;
 
         before(function(done) {
@@ -647,6 +648,17 @@ DRIVERS.forEach(function(driverName) {
                 // TravisCI seem to work fine though.
                 size: 1024,
                 storeName: 'storagename2'
+            });
+
+            // Same name, but different storeName since this has been malfunctioning before w/ IndexedDB.
+            localforage3 = localforage.createInstance({
+                name: 'storage2',
+                // We need a small value here
+                // otherwise local PhantomJS test
+                // will fail with SECURITY_ERR.
+                // TravisCI seem to work fine though.
+                size: 1024,
+                storeName: 'storagename3'
             });
 
             Promise.all([
@@ -690,7 +702,8 @@ DRIVERS.forEach(function(driverName) {
         it('retrieves the proper value when using the same key with other instances', function(done) {
             Promise.all([
                 localforage.setItem('key', 'value1'),
-                localforage2.setItem('key', 'value2')
+                localforage2.setItem('key', 'value2'),
+                localforage3.setItem('key', 'value3')
             ]).then(function() {
                 return Promise.all([
                     localforage.getItem('key').then(function(value) {
@@ -698,6 +711,9 @@ DRIVERS.forEach(function(driverName) {
                     }),
                     localforage2.getItem('key').then(function(value) {
                         expect(value).to.be('value2');
+                    }),
+                    localforage3.getItem('key').then(function(value) {
+                        expect(value).to.be('value3');
                     })
                 ]);
             }).then(function() {


### PR DESCRIPTION
We have a bug at the moment when you try to use the same `name` but with different `storeName` values. The exception you get in Chrome is `Failed to execute 'transaction' on 'IDBDatabase': One of the specified object stores was not found.`.

I've digged quite a bit into this and the problem is in this are: https://github.com/mozilla/localForage/blob/master/src/drivers/indexeddb.js#L41-L48

The `createObjectStore` is **only** possible to run from within an `onupgradeneeded` event. If you try to run it elsewhere, you get an exception (it needs the "version upgrade" transaction to be active).

Now, the thing here is that you only get this event when the *version* changes for the database (naturally...). This is how IndexedDB works, AFAIK, and I don't know any way around it. This means that `onupgradeneeded` will only get called for the very first `storeName` you provide; if you then try to create another `localForage` instance with another `storeName`, you will not get an `onupgradeneeded` event at all.

Possible workarounds:

1. Create the database differently, perhaps by having a list of `storeNames` in the options to `localForage.createInstance`. Loop over this list of `storeNames` in the `onupgradeneeded` event handler.
2. (Ab)use the version number handling in IndexedDB. I.e. increment the version every time we open the database... This is doable but requires a bit of quirks to get it working. This would probably provide the "cleanest" API to the user (but will be a bit of fiddling in the code with opening DB, querying version, closing, reopening with different versions etc...)
3. Maybe others. :smile: 

I think 1 is easiest and will probably implement that later during the day (European time). If anyone has better ideas, now is the time to suggest! :smile: 