### PR TITLE
(#381) - fix Android 4.0 support

### DIFF
--- a/src/drivers/indexeddb.js
+++ b/src/drivers/indexeddb.js
@@ -19,6 +19,159 @@
         return;
     }
 
+    var DETECT_BLOB_SUPPORT_STORE = 'local-forage-detect-blob-support';
+    var supportsBlobs;
+
+    // Abstracts constructing a Blob object, so it also works in older
+    // browsers that don't support the native Blob constructor. (i.e.
+    // old QtWebKit versions, at least).
+    function _createBlob(parts, properties) {
+        parts = parts || [];
+        properties = properties || {};
+        try {
+            return new Blob(parts, properties);
+        } catch (e) {
+            if (e.name !== 'TypeError') {
+                throw e;
+            }
+            var BlobBuilder = window.BlobBuilder ||
+                window.MSBlobBuilder ||
+                window.MozBlobBuilder ||
+                window.WebKitBlobBuilder;
+            var builder = new BlobBuilder();
+            for (var i = 0; i < parts.length; i += 1) {
+                builder.append(parts[i]);
+            }
+            return builder.getBlob(properties.type);
+        }
+    }
+
+    // Transform a binary string to an array buffer, because otherwise
+    // weird stuff happens when you try to work with the binary string directly.
+    // It is known.
+    // From http://stackoverflow.com/questions/14967647/ (continues on next line)
+    // encode-decode-image-with-base64-breaks-image (2013-04-21)
+    function _binStringToArrayBuffer(bin) {
+        var length = bin.length;
+        var buf = new ArrayBuffer(length);
+        var arr = new Uint8Array(buf);
+        for (var i = 0; i < length; i++) {
+            arr[i] = bin.charCodeAt(i);
+        }
+        return buf;
+    }
+
+    // Fetch a blob using ajax. This reveals bugs in Chrome < 43.
+    // For details on all this junk:
+    // https://github.com/nolanlawson/state-of-binary-data-in-the-browser#readme
+    function _blobAjax(url) {
+        return new Promise(function(resolve, reject) {
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', url);
+            xhr.withCredentials = true;
+            xhr.responseType = 'arraybuffer';
+
+            xhr.onreadystatechange = function() {
+                if (xhr.readyState !== 4) {
+                    return;
+                }
+                if (xhr.status === 200) {
+                    return resolve({
+                        response: xhr.response,
+                        type: xhr.getResponseHeader('Content-Type')
+                    });
+                }
+                reject({status: xhr.status, response: xhr.response});
+            };
+            xhr.send();
+        });
+    }
+
+    //
+    // Detect blob support. Chrome didn't support it until version 38.
+    // In version 37 they had a broken version where PNGs (and possibly
+    // other binary types) aren't stored correctly, because when you fetch
+    // them, the content type is always null.
+    //
+    // Furthermore, they have some outstanding bugs where blobs occasionally
+    // are read by FileReader as null, or by ajax as 404s.
+    //
+    // Sadly we use the 404 bug to detect the FileReader bug, so if they
+    // get fixed independently and released in different versions of Chrome,
+    // then the bug could come back. So it's worthwhile to watch these issues:
+    // 404 bug: https://code.google.com/p/chromium/issues/detail?id=447916
+    // FileReader bug: https://code.google.com/p/chromium/issues/detail?id=447836
+    //
+    function _checkBlobSupportWithoutCaching(idb) {
+        return new Promise(function(resolve, reject) {
+            var blob = _createBlob([''], {type: 'image/png'});
+            var txn = idb.transaction([DETECT_BLOB_SUPPORT_STORE], 'readwrite');
+            txn.objectStore(DETECT_BLOB_SUPPORT_STORE).put(blob, 'key');
+            txn.oncomplete = function() {
+                // have to do it in a separate transaction, else the correct
+                // content type is always returned
+                var blobTxn = idb.transaction([DETECT_BLOB_SUPPORT_STORE],
+                    'readwrite');
+                var getBlobReq = blobTxn.objectStore(
+                    DETECT_BLOB_SUPPORT_STORE).get('key');
+                getBlobReq.onerror = reject;
+                getBlobReq.onsuccess = function(e) {
+
+                    var storedBlob = e.target.result;
+                    var url = URL.createObjectURL(storedBlob);
+
+                    _blobAjax(url).then(function(res) {
+                        resolve(!!(res && res.type === 'image/png'));
+                    }, function() {
+                        resolve(false);
+                    }).then(function() {
+                        URL.revokeObjectURL(url);
+                    });
+                };
+            };
+        }).catch(function() {
+            return false; // error, so assume unsupported
+        });
+    }
+
+    function _checkBlobSupport(idb) {
+        if (typeof supportsBlobs === 'boolean') {
+            return Promise.resolve(supportsBlobs);
+        }
+        return _checkBlobSupportWithoutCaching(idb).then(function(value) {
+            supportsBlobs = value;
+            return supportsBlobs;
+        });
+    }
+
+    // encode a blob for indexeddb engines that don't support blobs
+    function _encodeBlob(blob) {
+        return new Promise(function(resolve, reject) {
+            var reader = new FileReader();
+            reader.onerror = reject;
+            reader.onloadend = function(e) {
+                var base64 = btoa(e.target.result || '');
+                resolve({
+                    __local_forage_encoded_blob: true,
+                    data: base64,
+                    type: blob.type
+                });
+            };
+            reader.readAsBinaryString(blob);
+        });
+    }
+
+    // decode an encoded blob
+    function _decodeBlob(encodedBlob) {
+        var arrayBuff = _binStringToArrayBuffer(atob(encodedBlob.data));
+        return _createBlob([arrayBuff], { type: encodedBlob.type});
+    }
+
+    // is this one of our fancy encoded blobs?
+    function _isEncodedBlob(value) {
+        return value && value.__local_forage_encoded_blob;
+    }
+
     // Open the IndexedDB database (automatically creates one if one didn't
     // previously exist), using any options set in the config.
     function _initStorage(options) {
@@ -38,9 +191,13 @@
             openreq.onerror = function() {
                 reject(openreq.error);
             };
-            openreq.onupgradeneeded = function() {
+            openreq.onupgradeneeded = function(e) {
                 // First time setup: create an empty object store
                 openreq.result.createObjectStore(dbInfo.storeName);
+                if (e.oldVersion <= 1) {
+                    // added when support for blob shims was added
+                    openreq.result.createObjectStore(DETECT_BLOB_SUPPORT_STORE);
+                }
             };
             openreq.onsuccess = function() {
                 dbInfo.db = openreq.result;
@@ -72,7 +229,9 @@
                     if (value === undefined) {
                         value = null;
                     }
-
+                    if (_isEncodedBlob(value)) {
+                        value = _decodeBlob(value);
+                    }
                     resolve(value);
                 };
 
@@ -103,7 +262,11 @@
                     var cursor = req.result;
 
                     if (cursor) {
-                        var result = iterator(cursor.value, cursor.key, iterationNumber++);
+                        var value = cursor.value;
+                        if (_isEncodedBlob(value)) {
+                            value = _decodeBlob(value);
+                        }
+                        var result = iterator(value, cursor.key, iterationNumber++);
 
                         if (result !== void(0)) {
                             resolve(result);
@@ -137,8 +300,16 @@
         }
 
         var promise = new Promise(function(resolve, reject) {
+            var dbInfo;
             self.ready().then(function() {
-                var dbInfo = self._dbInfo;
+                dbInfo = self._dbInfo;
+                return _checkBlobSupport(dbInfo.db);
+            }).then(function(blobSupport) {
+                if (!blobSupport && value instanceof Blob) {
+                    return _encodeBlob(value);
+                }
+                return value;
+            }).then(function(value) {
                 var transaction = dbInfo.db.transaction(dbInfo.storeName, 'readwrite');
                 var store = transaction.objectStore(dbInfo.storeName);
 

--- a/src/utils/serializer.js
+++ b/src/utils/serializer.js
@@ -24,6 +24,9 @@
     var TYPE_SERIALIZED_MARKER_LENGTH = SERIALIZED_MARKER_LENGTH +
                                         TYPE_ARRAYBUFFER.length;
 
+    var BLOB_TYPE_PREFIX = '~~local_forage_type~';
+    var BLOB_TYPE_PREFIX_REGEX = /^~~local_forage_type~([^~]+)~/;
+
     // Serialize a value, afterwards executing a callback (which usually
     // instructs the `setItem()` callback/promise to be executed). This is how
     // we store binary data with localStorage.
@@ -80,7 +83,9 @@
             var fileReader = new FileReader();
 
             fileReader.onload = function() {
-                var str = bufferToString(this.result);
+                // Backwards-compatible prefix for the blob type.
+                var str = BLOB_TYPE_PREFIX + value.type + '~' +
+                    bufferToString(this.result);
 
                 callback(SERIALIZED_MARKER + TYPE_BLOB + str);
             };
@@ -122,6 +127,14 @@
         var type = value.substring(SERIALIZED_MARKER_LENGTH,
                                    TYPE_SERIALIZED_MARKER_LENGTH);
 
+        var blobType;
+        // Backwards-compatible blob type serialization strategy.
+        // DBs created with older versions of localForage will simply not have the blob type.
+        if (type === TYPE_BLOB && BLOB_TYPE_PREFIX_REGEX.test(serializedString)) {
+            var matcher = serializedString.match(BLOB_TYPE_PREFIX_REGEX);
+            blobType = matcher[1];
+            serializedString = serializedString.substring(matcher[0].length);
+        }
         var buffer = stringToBuffer(serializedString);
 
         // Return the right type based on the code/type set during
@@ -130,7 +143,7 @@
             case TYPE_ARRAYBUFFER:
                 return buffer;
             case TYPE_BLOB:
-                return new Blob([buffer]);
+                return new Blob([buffer], {type: blobType});
             case TYPE_INT8ARRAY:
                 return new Int8Array(buffer);
             case TYPE_UINT8ARRAY:

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -79,6 +79,8 @@ DRIVERS.forEach(function(driverName) {
     describe(driverName + ' driver', function() {
         'use strict';
 
+        this.timeout(30000);
+
         before(function(done) {
             localforage.setDriver(driverName).then(done);
         });
@@ -809,6 +811,8 @@ DRIVERS.forEach(function(driverName) {
 
     describe(driverName + ' driver when ready() gets rejected', function() {
         'use strict';
+
+        this.timeout(30000);
 
         var _oldReady;
         var Promise;

--- a/test/test.datatypes.js
+++ b/test/test.datatypes.js
@@ -17,6 +17,8 @@ DRIVERS.forEach(function(driverName) {
     describe('Type handler for ' + driverName, function() {
         'use strict';
 
+        this.timeout(30000);
+
         before(function(done) {
             localforage.setDriver(driverName).then(done);
         });
@@ -312,9 +314,42 @@ DRIVERS.forEach(function(driverName) {
                             .to.be('[object Blob]');
                         expect(blob.size)
                             .to.be(testBlob.size);
-                        // TODO: localForage does not restore the mimeString!?
-                        // expect(blob.type)
-                        //     .to.be(testBlob.type);
+                        expect(blob.type)
+                            .to.be(testBlob.type);
+                        done();
+                    });
+                });
+            });
+        } else {
+            it.skip('saves binary (Blob) data (Blob type does not exist)');
+        }
+
+        if (typeof Blob === 'function') {
+            it('saves binary (Blob) data, iterate back', function(done) {
+                var fileParts = ['<a id=\"a\"><b id=\"b\">hey!<\/b><\/a>'];
+                var mimeString = 'text\/html';
+
+                var testBlob = new Blob(fileParts, { 'type' : mimeString });
+
+                localforage.setItem('blob', testBlob, function(err, blob) {
+                    expect(err).to.be(null);
+                    expect(blob.toString())
+                        .to.be('[object Blob]');
+                    expect(blob.size)
+                        .to.be(testBlob.size);
+                    expect(blob.type)
+                        .to.be(testBlob.type);
+                }).then(function() {
+                    localforage.iterate(function(blob, key) {
+                        if (key !== 'blob') {
+                            return;
+                        }
+                        expect(blob.toString())
+                            .to.be('[object Blob]');
+                        expect(blob.size)
+                            .to.be(testBlob.size);
+                        expect(blob.type)
+                            .to.be(testBlob.type);
                         done();
                     });
                 });

--- a/test/test.datatypes.js
+++ b/test/test.datatypes.js
@@ -5,6 +5,30 @@ var DRIVERS = [
     localforage.WEBSQL
 ];
 
+// Abstracts constructing a Blob object, so it also works in older
+// browsers that don't support the native Blob constructor. (i.e.
+// old QtWebKit versions, at least).
+function _createBlob(parts, properties) {
+    parts = parts || [];
+    properties = properties || {};
+    try {
+        return new Blob(parts, properties);
+    } catch (e) {
+        if (e.name !== 'TypeError') {
+            throw e;
+        }
+        var BlobBuilder = window.BlobBuilder ||
+            window.MSBlobBuilder ||
+            window.MozBlobBuilder ||
+            window.WebKitBlobBuilder;
+        var builder = new BlobBuilder();
+        for (var i = 0; i < parts.length; i += 1) {
+            builder.append(parts[i]);
+        }
+        return builder.getBlob(properties.type);
+    }
+}
+
 DRIVERS.forEach(function(driverName) {
     if ((!Modernizr.indexeddb && driverName === localforage.INDEXEDDB) ||
         (!Modernizr.localstorage && driverName === localforage.LOCALSTORAGE) ||
@@ -297,7 +321,7 @@ DRIVERS.forEach(function(driverName) {
                 var fileParts = ['<a id=\"a\"><b id=\"b\">hey!<\/b><\/a>'];
                 var mimeString = 'text\/html';
 
-                var testBlob = new Blob(fileParts, { 'type' : mimeString });
+                var testBlob = _createBlob(fileParts, { 'type' : mimeString });
 
                 localforage.setItem('blob', testBlob, function(err, blob) {
                     expect(err).to.be(null);
@@ -329,7 +353,7 @@ DRIVERS.forEach(function(driverName) {
                 var fileParts = ['<a id=\"a\"><b id=\"b\">hey!<\/b><\/a>'];
                 var mimeString = 'text\/html';
 
-                var testBlob = new Blob(fileParts, { 'type' : mimeString });
+                var testBlob = _createBlob(fileParts, { 'type' : mimeString });
 
                 localforage.setItem('blob', testBlob, function(err, blob) {
                     expect(err).to.be(null);


### PR DESCRIPTION
This replaces #381 with the _createBlob function
from #382. It's one additional commit on top of #382.

#381 is a great commit but I feel it was missing a few things:

* doesn't fix the tests
* doesn't work for all BlobBuilder vendor prefixes

With this commit, I have manually confirmed a 100%
green run in an Android 4.0.3 emulator.

Yes, I solved this problem with copypasta, but gzip
can sort those things out. :)