### PR TITLE
Prevent Safari and iOS from running IndexedDB tests

### DIFF
--- a/test/test.api.js
+++ b/test/test.api.js
@@ -68,7 +68,8 @@ describe('localForage', function() {
 });
 
 DRIVERS.forEach(function(driverName) {
-    if ((!Modernizr.indexeddb && driverName === localforage.INDEXEDDB) ||
+    if ((!localforage.supports(localforage.INDEXEDDB) &&
+         driverName === localforage.INDEXEDDB) ||
         (!Modernizr.localstorage && driverName === localforage.LOCALSTORAGE) ||
         (!Modernizr.websqldatabase && driverName === localforage.WEBSQL)) {
         // Browser doesn't support this storage library, so we exit the API

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -1,4 +1,4 @@
-/* global afterEach:true, before:true, beforeEach:true, describe:true, expect:true, it:true, Modernizr:true, Promise:true, require:true */
+/* global afterEach:true, before:true, beforeEach:true, describe:true, expect:true, it:true, Promise:true, require:true */
 var DRIVERS = [
     localforage.INDEXEDDB,
     localforage.LOCALSTORAGE,
@@ -70,8 +70,10 @@ describe('localForage', function() {
 DRIVERS.forEach(function(driverName) {
     if ((!localforage.supports(localforage.INDEXEDDB) &&
          driverName === localforage.INDEXEDDB) ||
-        (!Modernizr.localstorage && driverName === localforage.LOCALSTORAGE) ||
-        (!Modernizr.websqldatabase && driverName === localforage.WEBSQL)) {
+        (!localforage.supports(localforage.LOCALSTORAGE) &&
+         driverName === localforage.LOCALSTORAGE) ||
+        (!localforage.supports(localforage.WEBSQL) &&
+         driverName === localforage.WEBSQL)) {
         // Browser doesn't support this storage library, so we exit the API
         // tests.
         return;
@@ -721,13 +723,13 @@ DRIVERS.forEach(function(driverName) {
             // and after the target driver
             driverPreferedOrder = ['I am a not supported driver'];
 
-            if (!Modernizr.websqldatabase) {
+            if (!localforage.supports(localforage.WEBSQL)) {
                 driverPreferedOrder.push(localforage.WEBSQL);
             }
-            if (!Modernizr.indexeddb) {
+            if (!localforage.supports(localforage.INDEXEDDB)) {
                 driverPreferedOrder.push(localforage.INDEXEDDB);
             }
-            if (!Modernizr.localstorage) {
+            if (!localforage.supports(localforage.LOCALSTORAGE)) {
                 driverPreferedOrder.push(localforage.localStorage);
             }
 

--- a/test/test.datatypes.js
+++ b/test/test.datatypes.js
@@ -1,4 +1,4 @@
-/* global before:true, beforeEach:true, describe:true, expect:true, it:true, Modernizr:true */
+/* global before:true, beforeEach:true, describe:true, expect:true, it:true */
 var DRIVERS = [
     localforage.INDEXEDDB,
     localforage.LOCALSTORAGE,
@@ -32,8 +32,10 @@ function _createBlob(parts, properties) {
 DRIVERS.forEach(function(driverName) {
     if ((!localforage.supports(localforage.INDEXEDDB) &&
          driverName === localforage.INDEXEDDB) ||
-        (!Modernizr.localstorage && driverName === localforage.LOCALSTORAGE) ||
-        (!Modernizr.websqldatabase && driverName === localforage.WEBSQL)) {
+        (!localforage.supports(localforage.LOCALSTORAGE) &&
+         driverName === localforage.LOCALSTORAGE) ||
+        (!localforage.supports(localforage.WEBSQL) &&
+         driverName === localforage.WEBSQL)) {
         // Browser doesn't support this storage library, so we exit the API
         // tests.
         return;

--- a/test/test.datatypes.js
+++ b/test/test.datatypes.js
@@ -30,7 +30,8 @@ function _createBlob(parts, properties) {
 }
 
 DRIVERS.forEach(function(driverName) {
-    if ((!Modernizr.indexeddb && driverName === localforage.INDEXEDDB) ||
+    if ((!localforage.supports(localforage.INDEXEDDB) &&
+         driverName === localforage.INDEXEDDB) ||
         (!Modernizr.localstorage && driverName === localforage.LOCALSTORAGE) ||
         (!Modernizr.websqldatabase && driverName === localforage.WEBSQL)) {
         // Browser doesn't support this storage library, so we exit the API

--- a/test/test.drivers.js
+++ b/test/test.drivers.js
@@ -3,7 +3,7 @@ describe('Driver API', function() {
     'use strict';
 
     beforeEach(function(done) {
-        if (Modernizr.indexeddb) {
+        if (localforage.supports(localforage.INDEXEDDB)) {
             localforage.setDriver(localforage.INDEXEDDB, function() {
                 done();
             });
@@ -16,7 +16,7 @@ describe('Driver API', function() {
         }
     });
 
-    if ((Modernizr.indexeddb &&
+    if ((localforage.supports(localforage.INDEXEDDB) &&
          localforage.driver() === localforage.INDEXEDDB) ||
         (Modernizr.websqldatabase &&
          localforage.driver() === localforage.WEBSQL)) {
@@ -42,7 +42,7 @@ describe('Driver API', function() {
         });
     }
 
-    if (!Modernizr.indexeddb) {
+    if (!localforage.supports(localforage.INDEXEDDB)) {
         it("can't use unsupported IndexedDB [callback]", function(done) {
             var previousDriver = localforage.driver();
             expect(previousDriver).to.not.be(localforage.INDEXEDDB);

--- a/test/test.drivers.js
+++ b/test/test.drivers.js
@@ -1,4 +1,4 @@
-/* global beforeEach:true, describe:true, expect:true, it:true, Modernizr:true */
+/* global beforeEach:true, describe:true, expect:true, it:true */
 describe('Driver API', function() {
     'use strict';
 
@@ -7,7 +7,7 @@ describe('Driver API', function() {
             localforage.setDriver(localforage.INDEXEDDB, function() {
                 done();
             });
-        } else if (Modernizr.websqldatabase) {
+        } else if (localforage.supports(localforage.WEBSQL)) {
             localforage.setDriver(localforage.WEBSQL, function() {
                 done();
             });
@@ -18,7 +18,7 @@ describe('Driver API', function() {
 
     if ((localforage.supports(localforage.INDEXEDDB) &&
          localforage.driver() === localforage.INDEXEDDB) ||
-        (Modernizr.websqldatabase &&
+        (localforage.supports(localforage.WEBSQL) &&
          localforage.driver() === localforage.WEBSQL)) {
         it('can change to localStorage from ' + localforage.driver() +
            ' [callback]', function(done) {
@@ -87,7 +87,7 @@ describe('Driver API', function() {
         });
     }
 
-    if (!Modernizr.localstorage) {
+    if (!localforage.supports(localforage.LOCALSTORAGE)) {
         it("can't use unsupported localStorage [callback]", function(done) {
             var previousDriver = localforage.driver();
             expect(previousDriver).to.not.be(localforage.LOCALSTORAGE);
@@ -107,7 +107,8 @@ describe('Driver API', function() {
                 done();
             });
         });
-    } else if (!Modernizr.indexeddb && !Modernizr.websqldatabase) {
+    } else if (!localforage.supports(localforage.INDEXEDDB) &&
+               !localforage.supports(localforage.WEBSQL)) {
         it('can set already active localStorage [callback]', function(done) {
             var previousDriver = localforage.driver();
             expect(previousDriver).to.be(localforage.LOCALSTORAGE);
@@ -128,7 +129,7 @@ describe('Driver API', function() {
         });
     }
 
-    if (!Modernizr.websqldatabase) {
+    if (!localforage.supports(localforage.WEBSQL)) {
         it("can't use unsupported WebSQL [callback]", function(done) {
             var previousDriver = localforage.driver();
             expect(previousDriver).to.not.be(localforage.WEBSQL);

--- a/test/test.webworkers.js
+++ b/test/test.webworkers.js
@@ -6,9 +6,12 @@ var DRIVERS = [
 ];
 
 DRIVERS.forEach(function(driverName) {
-    if ((!Modernizr.indexeddb && driverName === localforage.INDEXEDDB) ||
-        (!Modernizr.localstorage && driverName === localforage.LOCALSTORAGE) ||
-        (!Modernizr.websqldatabase && driverName === localforage.WEBSQL)) {
+    if ((!localforage.supports(localforage.INDEXEDDB) &&
+         driverName === localforage.INDEXEDDB) ||
+        (!localforage.supports(localforage.LOCALSTORAGE) &&
+         driverName === localforage.LOCALSTORAGE) ||
+        (!localforage.supports(localforage.WEBSQL) &&
+         driverName === localforage.WEBSQL)) {
         // Browser doesn't support this storage library, so we exit the API
         // tests.
         return;


### PR DESCRIPTION
Tests check IndexedDB support (and, for now, only IndexedDB) against localForage's own `supports()` method instead of Modernizr.

Fixes #403.