### PR TITLE
chore: add module wide babel & browserify configs to fix 3rd party builds

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "loose": "all",
+  "plugins": ["system-import-transformer"]
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,12 +34,9 @@ module.exports = exports = function(grunt) {
     grunt.initConfig({
         babel: {
             options: {
-                loose: 'all',
                 modules: 'umd',
                 moduleIds: true,
-                // sourceMap: true,
-                getModuleId: babelModuleIdProvider,
-                plugins: ['system-import-transformer']
+                getModuleId: babelModuleIdProvider
             },
             dist: {
                 files: {
@@ -55,10 +52,8 @@ module.exports = exports = function(grunt) {
             client: {
                 options: {
                     transform: [['babelify', {
-                        loose: 'all',
                         moduleIds: true,
-                        getModuleId: babelModuleIdProvider,
-                        plugins: ['system-import-transformer']
+                        getModuleId: babelModuleIdProvider
                     }]]
                 },
                 src: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,18 +49,8 @@ module.exports = exports = function(grunt) {
             }
         },
         browserify: {
-            client: {
-                options: {
-                    transform: [['babelify', {
-                        moduleIds: true,
-                        getModuleId: babelModuleIdProvider
-                    }]]
-                },
-                src: [
-                    'bower_components/es6-promise/promise.js',
-                    'src/**/*.js',
-                    'test/runner.browserify.js'
-                ],
+            package_bundling_test: {
+                src: 'test/runner.browserify.js',
                 dest: 'test/localforage.browserify.js'
             }
         },
@@ -211,7 +201,7 @@ module.exports = exports = function(grunt) {
                     'test/runner.js',
                     'test/test.*.*'
                 ],
-                tasks: ['jshint', 'jscs', 'shell:component', 'browserify', 'mocha:unit']
+                tasks: ['jshint', 'jscs', 'shell:component', 'browserify:package_bundling_test', 'mocha:unit']
             }
         }
     });
@@ -230,7 +220,7 @@ module.exports = exports = function(grunt) {
         'jshint',
         'jscs',
         'shell:component',
-        'browserify',
+        'browserify:package_bundling_test',
         'connect:test',
         'mocha'
     ];

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   },
   "dependencies": {
     "promise": "^5.0.0"
+  },
+  "browserify": {
+    "transform": ["babelify"]
   }
 }

--- a/test/runner.browserify.js
+++ b/test/runner.browserify.js
@@ -1,1 +1,5 @@
-window.localforage = require('./../dist/localforage');
+if (typeof Promise === 'undefined') {
+    require('../bower_components/es6-promise/promise');
+}
+// require localforage as defined in package.json
+window.localforage = require('../');


### PR DESCRIPTION
Properly resolves #412 & #413 for the ES6 codebase.