### PR TITLE
Fix the 'iterationNumber' inconsistency of localStorage iterate method

### DIFF
--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -107,6 +107,7 @@
             var keyPrefix = self._dbInfo.keyPrefix;
             var keyPrefixLength = keyPrefix.length;
             var length = localStorage.length;
+            var iterationNumber = 1;
 
             for (var i = 0; i < length; i++) {
                 var key = localStorage.key(i);
@@ -123,7 +124,7 @@
                     value = serializer.deserialize(value);
                 }
 
-                value = iterator(value, key.substring(keyPrefixLength), i + 1);
+                value = iterator(value, key.substring(keyPrefixLength), iterationNumber++);
 
                 if (value !== void(0)) {
                     return value;

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -261,6 +261,9 @@ DRIVERS.forEach(function(driverName) {
         });
 
         it('should iterate() through only its own keys/values', function(done) {
+
+            var iterationNumberConcat = '';
+
             localStorage.setItem('local', 'forage');
 
             localforage.setItem('office', 'Initech').then(function() {
@@ -269,16 +272,21 @@ DRIVERS.forEach(function(driverName) {
                 // Loop through all key/value pairs; local: 'forage' set
                 // manually should not be returned.
                 var numberOfItems = 0;
-                localforage.iterate(function(value, key) {
+                localforage.iterate(function(value, key, iterationNumber) {
                     // Returning defined value will break the cycle.
                     expect(key).to.not.be('local');
                     expect(value).to.not.be('forage');
                     numberOfItems++;
+                    iterationNumberConcat += iterationNumber;
                 }, function(err) {
                     if (!err) {
                         // Only two items were set, so that's all we should
                         // have!
                         expect(numberOfItems).to.be(2);
+
+                        // Only one item was set on localForage storage,
+                        // so we should get '1' and not '12'
+                        expect(iterationNumberConcat).to.be('1');
 
                         done();
                     }

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -262,8 +262,6 @@ DRIVERS.forEach(function(driverName) {
 
         it('should iterate() through only its own keys/values', function(done) {
 
-            var iterationNumberConcat = '';
-
             localStorage.setItem('local', 'forage');
 
             localforage.setItem('office', 'Initech').then(function() {
@@ -272,6 +270,7 @@ DRIVERS.forEach(function(driverName) {
                 // Loop through all key/value pairs; local: 'forage' set
                 // manually should not be returned.
                 var numberOfItems = 0;
+                var iterationNumberConcat = '';
                 localforage.iterate(function(value, key, iterationNumber) {
                     // Returning defined value will break the cycle.
                     expect(key).to.not.be('local');

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -280,12 +280,9 @@ DRIVERS.forEach(function(driverName) {
                     iterationNumberConcat += iterationNumber;
                 }, function(err) {
                     if (!err) {
-                        // Only two items were set, so that's all we should
-                        // have!
-                        expect(numberOfItems).to.be(2);
-
-                        // Only one item was set on localForage storage,
-                        // so we should get '1' and not '12'
+                        // While there are 2 items in localStorage,
+                        // only one item was set on localForage storage.
+                        expect(numberOfItems).to.be(1);
                         expect(iterationNumberConcat).to.be('1');
 
                         done();


### PR DESCRIPTION
I would expect that the iterationNumber starts from 1 and increments only by 1 for each item found on localStorage for the specific localForage instance.

For example, in my use case I have 2 different instances of localForage on localStorage, plus other non-localForage related items on localStorage. 

Unfortunately, the iterationNumber is related to the order of the item on the entire localStorage, so there are gaps on its value when iterating on a specific instance of localForage. And this is not useful at all.

Note: Feel free to change the test to your liking, that was a quick shot.
