### PR TITLE
fix(localStorageDriver.iterate): fix the iterationNumber logic

### DIFF
--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -107,6 +107,7 @@
             var keyPrefix = self._dbInfo.keyPrefix;
             var keyPrefixLength = keyPrefix.length;
             var length = localStorage.length;
+            var iterationNumber = 1;
 
             for (var i = 0; i < length; i++) {
                 var key = localStorage.key(i);
@@ -123,7 +124,7 @@
                     value = serializer.deserialize(value);
                 }
 
-                value = iterator(value, key.substring(keyPrefixLength), i + 1);
+                value = iterator(value, key.substring(keyPrefixLength), iterationNumber++);
 
                 if (value !== void(0)) {
                     return value;

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -262,6 +262,7 @@ DRIVERS.forEach(function(driverName) {
         });
 
         it('should iterate() through only its own keys/values', function(done) {
+
             localStorage.setItem('local', 'forage');
             localforage.setItem('office', 'Initech').then(function() {
                 return localforage.setItem('name', 'Bob');
@@ -269,15 +270,21 @@ DRIVERS.forEach(function(driverName) {
                 // Loop through all key/value pairs; {local: 'forage'} set
                 // manually should not be returned.
                 var numberOfItems = 0;
-                localforage.iterate(function(value, key) {
+                var iterationNumberConcat = '';
+                localforage.iterate(function(value, key, iterationNumber) {
                     expect(key).to.not.be('local');
                     expect(value).to.not.be('forage');
                     numberOfItems++;
+                    iterationNumberConcat += iterationNumber;
                 }, function(err) {
                     if (!err) {
                         // While there are 3 items in localStorage,
-                        // only two items were set using localForage.
+                        // only 2 items were set using localForage.
                         expect(numberOfItems).to.be(2);
+
+                        // Only 2 items were set using localForage,
+                        // so we should get '12' and not '123'
+                        expect(iterationNumberConcat).to.be('12');
 
                         done();
                     }


### PR DESCRIPTION
I added this *necessary* addition to the localStorage's `iterate` fix to the `master` too (it was added to the `pre-ES6` branch a day ago), so that it is also included to the 1.3 release.

I hope that you can also merge the other PR to the `pre-ES6` and upload a 1.2.9 version on NPM that includes this fix.

Thanks!