### PR TITLE
feat(package.json): direct webpack users to use the dist build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 components
 test/localforage.browserify.js
 test/localforage.component.js
+test/localforage.webpack.js
 
 # Logs + Sauce Labs Tests
 *.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,12 +21,8 @@ module.exports = exports = function(grunt) {
 
     grunt.initConfig({
         browserify: {
-            client: {
-                src: [
-                    'bower_components/es6-promise/promise.js',
-                    'src/**/*.js',
-                    'test/runner.browserify.js'
-                ],
+            package_bundling_test: {
+                src: 'test/runner.browserify.js',
                 dest: 'test/localforage.browserify.js'
             }
         },
@@ -110,6 +106,7 @@ module.exports = exports = function(grunt) {
                         'http://localhost:9999/test/test.require.html',
                         'http://localhost:9999/test/test.require.unbundled.html',
                         'http://localhost:9999/test/test.browserify.html',
+                        'http://localhost:9999/test/test.webpack.html',
                         'http://localhost:9999/test/test.callwhenready.html',
                         'http://localhost:9999/test/test.customdriver.html'
                     ]
@@ -177,7 +174,23 @@ module.exports = exports = function(grunt) {
                     'test/runner.js',
                     'test/test.*.*'
                 ],
-                tasks: ['jshint', 'jscs', 'shell:component', 'browserify', 'mocha:unit']
+                tasks: [
+                    'jshint',
+                    'jscs',
+                    'shell:component',
+                    'browserify:package_bundling_test',
+                    'webpack:package_bundling_test',
+                    'mocha:unit'
+                ]
+            }
+        },
+        webpack: {
+            package_bundling_test: {
+                entry: './test/runner.webpack.js',
+                output: {
+                    path: 'test/',
+                    filename: 'localforage.webpack.js'
+                }
             }
         }
     });
@@ -196,7 +209,8 @@ module.exports = exports = function(grunt) {
         'jshint',
         'jscs',
         'shell:component',
-        'browserify',
+        'browserify:package_bundling_test',
+        'webpack:package_bundling_test',
         'connect:test',
         'mocha'
     ];

--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ define(['localforage'], function(localforage) {
 });
 ```
 
+## Browserify and Webpack
+
+localForage should work with both Browserify and Webpack.
+You should not override the entry point defined in `package.json`.
+
+**For Webpack:** currently, you need to require localForage as `require('script!localforage')`.
+
 ## Web Workers
 
 Web Worker support in Firefox is blocked by [bug 701634][]. Until it is fixed,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "localforage",
   "author": "Mozilla",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "description": "Offline storage, improved.",
   "keywords": [
     "indexeddb",
@@ -40,7 +40,7 @@
   },
   "browser": "src/localforage.js",
   "main": "dist/localforage.js",
-  "licence": "Apache-2.0",
+  "webpack": "dist/localforage.js",
   "bugs": {
     "url": "http://github.com/mozilla/localForage/issues"
   },

--- a/package.json
+++ b/package.json
@@ -33,10 +33,14 @@
     "grunt-mocha": "^0.4.10",
     "grunt-saucelabs": "^5.1.2",
     "grunt-shell": "^0.6.4",
+    "grunt-webpack": "^1.0.11",
     "load-grunt-tasks": "^0.4.0",
     "mocha": "^1.18.2",
     "phantomjs": "^1.9.7-12",
-    "uglify-js": "^2.3.x"
+    "script-loader": "^0.6.1",
+    "uglify-js": "^2.3.x",
+    "webpack": "^1.11.0",
+    "webpack-dev-server": "^1.10.1"
   },
   "browser": "src/localforage.js",
   "main": "dist/localforage.js",

--- a/test/runner.browserify.js
+++ b/test/runner.browserify.js
@@ -1,1 +1,5 @@
-window.localforage = require('./../dist/localforage');
+if (typeof Promise === 'undefined') {
+    require('../bower_components/es6-promise/promise');
+}
+// require localforage as defined in package.json
+window.localforage = require('../');

--- a/test/runner.webpack.js
+++ b/test/runner.webpack.js
@@ -1,0 +1,2 @@
+// require localforage (with webpack/script-loader) as defined in package.json
+require('script!../');

--- a/test/test.webpack.html
+++ b/test/test.webpack.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>localForage WebPack Tests!</title>
+
+    <link rel="stylesheet" href="/bower_components/mocha/mocha.css">
+
+    <script src="/bower_components/assert/assert.js"></script>
+    <script src="/bower_components/mocha/mocha.js"></script>
+
+    <script src="/bower_components/expect/index.js"></script>
+
+    <!-- Modernizr  -->
+    <script src="/bower_components/modernizr/modernizr.js"></script>
+
+    <!-- localForage -->
+    <script src="/test/localforage.webpack.js"></script>
+
+    <!-- Test runner -->
+    <script src="/test/runner.js"></script>
+
+    <!-- specs -->
+    <script src="/test/test.api.js"></script>
+    <script src="/test/test.config.js"></script>
+    <script src="/test/test.datatypes.js"></script>
+    <script src="/test/test.drivers.js"></script>
+    <script src="/test/test.iframes.js"></script>
+    <script src="/test/test.webworkers.js"></script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+  </body>
+</html>


### PR DESCRIPTION
This is a backport of #417 to the v1.2 / pre-es6-branch containing:
* package.json fixes for webpack users (as [requested](https://github.com/mozilla/localForage/pull/417#issuecomment-135514532) at #417
* browserify & webpack test changes to use localforage as defined package.json