### PR TITLE
Fix #342 : multiple stores on the same database

### DIFF
--- a/src/drivers/localstorage.js
+++ b/src/drivers/localstorage.js
@@ -39,6 +39,10 @@
 
         dbInfo.keyPrefix = dbInfo.name + '/';
 
+        if (dbInfo.storeName !== self._defaultConfig.storeName) {
+            dbInfo.keyPrefix += dbInfo.storeName + '/';
+        }
+
         self._dbInfo = dbInfo;
 
         return System.import('./../utils/serializer').then(function(lib) {

--- a/src/localforage.js
+++ b/src/localforage.js
@@ -146,7 +146,8 @@
             this.LOCALSTORAGE = DriverType.LOCALSTORAGE;
             this.WEBSQL = DriverType.WEBSQL;
 
-            this._config = extend({}, DefaultConfig, options);
+            this._defaultConfig = extend({}, DefaultConfig);
+            this._config = extend({}, this._defaultConfig, options);
             this._driverSet = null;
             this._ready = false;
             this._dbInfo = null;

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -722,6 +722,7 @@ DRIVERS.forEach(function(driverName) {
     describe(driverName + ' driver multiple instances', function() {
         'use strict';
         var localforage2 = null;
+        var localforage3 = null;
         var Promise;
 
         before(function(done) {
@@ -737,9 +738,21 @@ DRIVERS.forEach(function(driverName) {
                 storeName: 'storagename2'
             });
 
+            // Same name, but different storeName since this has been malfunctioning before w/ IndexedDB.
+            localforage3 = localforage.createInstance({
+                name: 'storage2',
+                // We need a small value here
+                // otherwise local PhantomJS test
+                // will fail with SECURITY_ERR.
+                // TravisCI seem to work fine though.
+                size: 1024,
+                storeName: 'storagename3'
+            });
+
             Promise.all([
                 localforage.setDriver(driverName),
-                localforage2.setDriver(driverName)
+                localforage2.setDriver(driverName),
+                localforage3.setDriver(driverName)
             ])
             .then(function() {
                 done();
@@ -749,7 +762,8 @@ DRIVERS.forEach(function(driverName) {
         beforeEach(function(done) {
             Promise.all([
                 localforage.clear(),
-                localforage2.clear()
+                localforage2.clear(),
+                localforage3.clear()
             ]).then(function() {
                 done();
             });
@@ -778,7 +792,8 @@ DRIVERS.forEach(function(driverName) {
         it('retrieves the proper value when using the same key with other instances', function(done) {
             Promise.all([
                 localforage.setItem('key', 'value1'),
-                localforage2.setItem('key', 'value2')
+                localforage2.setItem('key', 'value2'),
+                localforage3.setItem('key', 'value3')
             ]).then(function() {
                 return Promise.all([
                     localforage.getItem('key').then(function(value) {
@@ -786,6 +801,9 @@ DRIVERS.forEach(function(driverName) {
                     }),
                     localforage2.getItem('key').then(function(value) {
                         expect(value).to.be('value2');
+                    }),
+                    localforage3.getItem('key').then(function(value) {
+                        expect(value).to.be('value3');
                     })
                 ]);
             }).then(function() {

--- a/test/test.api.js
+++ b/test/test.api.js
@@ -738,7 +738,7 @@ DRIVERS.forEach(function(driverName) {
                 storeName: 'storagename2'
             });
 
-            // Same name, but different storeName since this has been malfunctioning before w/ IndexedDB.
+            // Same name, but different storeName
             localforage3 = localforage.createInstance({
                 name: 'storage2',
                 // We need a small value here
@@ -772,13 +772,20 @@ DRIVERS.forEach(function(driverName) {
         it('is not be able to access values of other instances', function(done) {
             Promise.all([
                 localforage.setItem('key1', 'value1a'),
-                localforage2.setItem('key2', 'value2a')
+                localforage2.setItem('key2', 'value2a'),
+                localforage3.setItem('key3', 'value3a')
             ]).then(function() {
                 return Promise.all([
                     localforage.getItem('key2').then(function(value) {
                         expect(value).to.be(null);
                     }),
                     localforage2.getItem('key1').then(function(value) {
+                        expect(value).to.be(null);
+                    }),
+                    localforage2.getItem('key3').then(function(value) {
+                        expect(value).to.be(null);
+                    }),
+                    localforage3.getItem('key2').then(function(value) {
                         expect(value).to.be(null);
                     })
                 ]);

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -197,7 +197,7 @@ describe('Config API', function() {
                     });
                 });
             } else if (localforage.driver() === localforage.LOCALSTORAGE) {
-                var dbValue = JSON.parse(localStorage['My Cool App/some key']);
+                var dbValue = JSON.parse(localStorage['My Cool App/storeFront/some key']);
 
                 expect(dbValue).to.be(value);
                 done();


### PR DESCRIPTION
Implementation summary for IndexedDB:
- Keep track on all running forages per database.
- Wait for them to be ready before processing any new connection to the same
database.
- Probe the current database to check if an upgrade is required (greater version
or new store).
- If so, upgrade the database by reopening it.
- Share the final connection (original or upgraded) amongts all running forages.

Implementation summary for localStorage:
- Prefix the key with the store name (after database), unless it's the default
name.