### PR TITLE
Check if self is present (not in webworker).

### DIFF
--- a/src/localforage.js
+++ b/src/localforage.js
@@ -426,5 +426,5 @@ var localForage = (function(globalObject) {
     // The actual localForage object that we expose as a module or via a
     // global. It's extended by pulling in one of our other libraries.
     return new LocalForage();
-})(typeof window !== 'undefined' ? window : self);
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : {}));
 export default localForage;


### PR DESCRIPTION
Permits webpack to use the package since self will only resolve is needed. If neither self or window are present, and empty object is used.

Fixes #469 