### PR TITLE
Fixed a few bugs that manifest when not enough space is available

### DIFF
--- a/src/drivers/indexeddb.js
+++ b/src/drivers/indexeddb.js
@@ -124,6 +124,7 @@ var asyncStorage = (function(globalObject) {
                     });
                 };
             };
+            txn.onerror = txn.onabort = reject;
         }).catch(function() {
             return false; // error, so assume unsupported
         });
@@ -298,9 +299,21 @@ var asyncStorage = (function(globalObject) {
                 };
             }
 
-            openreq.onerror = function() {
+            var errHandlerCalled = false;
+            var errHandler = function () {
+                if (errHandlerCalled) {
+                    return;
+                }
+                errHandlerCalled = true;
                 reject(openreq.error);
             };
+
+            openreq.onerror = errHandler;
+            // The openreq can already be in a failed state. In this case the handler gets never called.
+            // This probably is a bug in firefox.
+            if (openreq.error) {
+                errHandler();
+            }
 
             openreq.onsuccess = function() {
                 resolve(openreq.result);
@@ -464,7 +477,6 @@ var asyncStorage = (function(globalObject) {
                     value = undefined;
                 }
 
-                var req = store.put(value, key);
                 transaction.oncomplete = function() {
                     // Cast to undefined so the value passed to
                     // callback/promise is the same as what one would get out
@@ -482,6 +494,8 @@ var asyncStorage = (function(globalObject) {
                     var err = req.error ? req.error : req.transaction.error;
                     reject(err);
                 };
+
+                var req = store.put(value, key);
             }).catch(reject);
         });
 


### PR DESCRIPTION
The line txn.onerror = txn.onabort = reject; is self explanatory, there hasn't been any error handler set.

Then the errHandler stuff:
There is an issue with indexedDb.open, which returns request, that has
the success and error handlers. However, this function can also fail
before the handlers are set. That is why I added check after setting
the handlers, to see, if the object isn't already in error state. Also there is a protection from being called twice.

Moving the line "var req = store.put(value, key);" after setting the handlers:
If the store.put finished before the handlers are set on the transaction, those handlers never get called. This pattern is pretty common in the code, but I didn't have enough courage to fix it all over the code. In this exact place it was causing a problem. I recommend going trough the code and look for db.transaction - there are many more suspicious instances of this.