### PR TITLE
test(websql): test the case that openDriver fails

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,6 +126,7 @@ module.exports = exports = function(grunt) {
                     urls: [
                         'http://localhost:9999/test/test.component.html',
                         'http://localhost:9999/test/test.nodriver.html',
+                        'http://localhost:9999/test/test.faultydriver.html',
                         'http://localhost:9999/test/test.main.html',
                         'http://localhost:9999/test/test.min.html',
                         'http://localhost:9999/test/test.require.html',

--- a/test/test.faultydriver.html
+++ b/test/test.faultydriver.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>localForage Tests!</title>
+
+    <link rel="stylesheet" href="/bower_components/mocha/mocha.css">
+
+    <script src="/bower_components/assert/assert.js"></script>
+    <script src="/bower_components/mocha/mocha.js"></script>
+
+    <script src="/bower_components/expect/index.js"></script>
+
+    <script>
+
+        try {
+            window.originalOpenDatabase = window.openDatabase;
+            window.openDatabase = function faultyOpenDatabase () {
+                throw new Error('OpenDatabase Faulty Driver Test!');
+            };
+        } catch (error) { }
+
+    </script>
+
+    <!-- Modernizr  -->
+    <script src="/bower_components/modernizr/modernizr.js"></script>
+
+    <!-- Test runner -->
+    <script src="/test/runner.js"></script>
+
+    <!-- localForage -->
+    <script src="/dist/localforage.js"></script>
+
+    <!-- specs -->
+    <script src="/test/test.faultydriver.js"></script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+  </body>
+</html>

--- a/test/test.faultydriver.js
+++ b/test/test.faultydriver.js
@@ -1,0 +1,31 @@
+/* global describe:true, expect:true, it:true */
+describe('When Driver Fails to Initialize', function() {
+    'use strict';
+
+    var FAULTYDRIVERS = [
+        localforage.WEBSQL
+    ];
+
+    FAULTYDRIVERS.forEach(function(driverName) {
+        it('fails to setDriver ' + driverName + ' [callback]', function(done) {
+            localforage.setDriver(driverName, function() {
+                localforage.ready(function(err) {
+                    expect(err).to.be.an(Error);
+                    expect(err.message).to.be('No available storage method found.');
+                    done();
+                });
+            });
+        });
+
+        it('fails to setDriver ' + driverName + ' [promise]', function(done) {
+            localforage.setDriver(driverName).then(function() {
+                return localforage.ready();
+            }).then(null, function(err) {
+                expect(err).to.be.an(Error);
+                expect(err.message).to.be('No available storage method found.');
+                done();
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
Related test cases for #510 and #511.
The required change to make the test pass is to reject in case that openDatabase fails (instead of setting the localforage driver).
```js
try {
    dbInfo.db = openDatabase(dbInfo.name, String(dbInfo.version),
                             dbInfo.description, dbInfo.size);
} catch (e) {
    reject(e);
}
```
The required src change is left for @marcucio to implement since he initially found the issue.