### PR TITLE
docs(CONTRIBUTING): add codepen example as basis for issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,10 @@ Please
 [check the existing issues](https://github.com/mozilla/localForage/issues) to
 make sure your issue hasn't already been filed.
 
-If you have a bug to report, please file it. If you'd like to see a feature
+If you have a bug to report, please file it.
+You are also encouradged to create an example (or [edit an existing one](http://codepen.io/thgreasi/pen/ojYKeE)) to showcase your issue.
+
+If you'd like to see a feature
 implemented, you can file an issue, but know that pull requests for small
 things like adding a line in a config file will get more attention than an
 issue asking someone else to do it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Please
 make sure your issue hasn't already been filed.
 
 If you have a bug to report, please file it.
-You are also encouradged to create an example (or [edit an existing one](http://codepen.io/thgreasi/pen/ojYKeE)) to showcase your issue.
+You are also encouraged to create an example (or [edit an existing one](http://codepen.io/thgreasi/pen/ojYKeE)) to showcase your issue.
 
 If you'd like to see a feature
 implemented, you can file an issue, but know that pull requests for small


### PR DESCRIPTION
Maybe something like this could also be added in README.
The code of this pen is based on one of the provided examples of this repo and has been used in some of the reported issues.
It obviously can be replaced by something better.